### PR TITLE
Fix incorrectly published data

### DIFF
--- a/Timetables/Vip/Lines/Tram91/Tram91.cs
+++ b/Timetables/Vip/Lines/Tram91/Tram91.cs
@@ -7,5 +7,6 @@ internal class Tram91 : ICompleteLine
         new Tram91From20240205(),
         new Tram91From20240211(),
         new Tram91From20240610(),
+        new Tram91From20241021Until20241102(),
     ];
 }

--- a/Timetables/Vip/Lines/Tram91/Tram91.cs
+++ b/Timetables/Vip/Lines/Tram91/Tram91.cs
@@ -8,5 +8,6 @@ internal class Tram91 : ICompleteLine
         new Tram91From20240211(),
         new Tram91From20240610(),
         new Tram91From20241021Until20241102(),
+        new Tram91From20241104(),
     ];
 }

--- a/Timetables/Vip/Lines/Tram91/Tram91From20241021Until20241102.cs
+++ b/Timetables/Vip/Lines/Tram91/Tram91From20241021Until20241102.cs
@@ -1,0 +1,15 @@
+using Timetables.Models;
+
+namespace Timetables.Vip.Lines.Tram91;
+
+public class Tram91From20241021Until20241102 : ILineInstance
+{
+    private static readonly Tram91From20240610 Original = new();
+    public DateOnly ValidFrom { get; } = new(2024, 10, 21);
+    public DateOnly? ValidUntilInclusive() => new(2024, 11, 2);
+
+    public Line Line { get; } = Original.Line with
+    {
+        Routes = Original.Line.Routes.Select(route => route.WithoutStop(Stops.LuisenplatzSüdParkSanssouci)).ToArray(),
+    };
+}

--- a/Timetables/Vip/Lines/Tram91/Tram91From20241104.cs
+++ b/Timetables/Vip/Lines/Tram91/Tram91From20241104.cs
@@ -1,0 +1,11 @@
+using Timetables.Models;
+
+namespace Timetables.Vip.Lines.Tram91;
+
+public class Tram91From20241104 : ILineInstance
+{
+    private static readonly Tram91From20240211 Original = new();
+    public DateOnly ValidFrom { get; } = new(2024, 11, 4);
+
+    public Line Line { get; } = Original.Line;
+}

--- a/Timetables/Vip/Lines/Tram92/Tram92.cs
+++ b/Timetables/Vip/Lines/Tram92/Tram92.cs
@@ -6,5 +6,6 @@ internal class Tram92 : ICompleteLine
     [
         new Tram92From20240102(), new Tram92From20240422(), new Tram92From20240606(), new Tram92From20240608(),
         new Tram92From20240610(), new Tram92From20240816Until20240818(), new Tram92From20240921Until20240922(),
+        new Tram92From20240923(),
     ];
 }

--- a/Timetables/Vip/Lines/Tram92/Tram92.cs
+++ b/Timetables/Vip/Lines/Tram92/Tram92.cs
@@ -6,6 +6,6 @@ internal class Tram92 : ICompleteLine
     [
         new Tram92From20240102(), new Tram92From20240422(), new Tram92From20240606(), new Tram92From20240608(),
         new Tram92From20240610(), new Tram92From20240816Until20240818(), new Tram92From20240921Until20240922(),
-        new Tram92From20240923(),
+        new Tram92From20240923(), new Tram92From20241012Until20241013(),
     ];
 }

--- a/Timetables/Vip/Lines/Tram92/Tram92.cs
+++ b/Timetables/Vip/Lines/Tram92/Tram92.cs
@@ -6,6 +6,6 @@ internal class Tram92 : ICompleteLine
     [
         new Tram92From20240102(), new Tram92From20240422(), new Tram92From20240606(), new Tram92From20240608(),
         new Tram92From20240610(), new Tram92From20240816Until20240818(), new Tram92From20240921Until20240922(),
-        new Tram92From20240923(), new Tram92From20241012Until20241013(),
+        new Tram92From20240923(), new Tram92From20241012Until20241013(), new Tram92From20241104(),
     ];
 }

--- a/Timetables/Vip/Lines/Tram92/Tram92From20240923.cs
+++ b/Timetables/Vip/Lines/Tram92/Tram92From20240923.cs
@@ -1,6 +1,111 @@
+using Timetables.Models;
+
 namespace Timetables.Vip.Lines.Tram92;
 
-public class Tram92From20240923
+using static Minutes;
+
+public class Tram92From20240923 : ILineInstance
 {
-    
+    private static readonly Tram92From20240610 Original = new();
+    public DateOnly ValidFrom { get; } = new(2024, 9, 23);
+
+    public Line Line { get; } = Original.Line with
+    {
+        Routes = Original.Line.Routes.Select(route =>
+            {
+                if (route.StopPositions[0].Stop != Stops.Kirschallee)
+                {
+                    return route;
+                }
+
+                return route with
+                {
+                    TimeProfiles = route.TimeProfiles.Select(profile => profile with
+                    {
+                        StopDistances = [..profile.StopDistances[..6], M2, ..profile.StopDistances[7..]],
+                    }).ToArray()
+                };
+            }).Select((route, index) =>
+            {
+                // Special case for evening trips from S Hbf and Marie-Juchacz-Str. to Kirschallee.
+                if (index is 6 or 8)
+                {
+                    return route with
+                    {
+                        TimeProfiles =
+                        [
+                            new Line.Route.TimeProfile
+                            {
+                                StopDistances =
+                                [
+                                    ..route.TimeProfiles[0].StopDistances[..^7], M2,
+                                    ..route.TimeProfiles[0].StopDistances[^6..]
+                                ]
+                            },
+                            new Line.Route.TimeProfile
+                            {
+                                StopDistances =
+                                [
+                                    ..route.TimeProfiles[1].StopDistances[..^6], M2,
+                                    ..route.TimeProfiles[1].StopDistances[^5..]
+                                ]
+                            }
+                        ]
+                    };
+                }
+
+                if (route.StopPositions[^1].Stop != Stops.Kirschallee)
+                {
+                    return route;
+                }
+
+                return route with
+                {
+                    TimeProfiles = route.TimeProfiles.Select(profile => profile with
+                    {
+                        StopDistances = [..profile.StopDistances[..^7], M2, ..profile.StopDistances[^6..]],
+                    }).ToArray()
+                };
+            })
+            .ToArray(),
+        TripsCreate = Original.Line.TripsCreate.Select(tripCreate =>
+            {
+                if (!tripCreate.TripCreateStartsAt(Stops.Kirschallee) || tripCreate.StartTime > new TimeOnly(19, 15) ||
+                    tripCreate.StartTime < new TimeOnly(2, 0) ||
+                    (tripCreate.DaysOfOperation & DaysOfOperation.Weekend) != 0)
+                {
+                    return tripCreate;
+                }
+
+                return tripCreate with
+                {
+                    StartTime = tripCreate.StartTime.AddMinutes(1),
+                };
+            }).Select(tripCreate =>
+            {
+                if (!tripCreate.TripCreateEndsAt(Stops.Kirschallee) || tripCreate.StartTime > new TimeOnly(20, 0) ||
+                    tripCreate.StartTime < new TimeOnly(2, 0) ||
+                    (tripCreate.DaysOfOperation & DaysOfOperation.Weekend) != 0 && tripCreate.StartTime > new TimeOnly(19, 38))
+                {
+                    return tripCreate;
+                }
+
+                return tripCreate with
+                {
+                    StartTime = tripCreate.StartTime.AddMinutes(2),
+                };
+            })
+            .ToArray(),
+    };
+}
+
+file static class TripCreateExtensions
+{
+    private static readonly Tram92From20240610 Original = new();
+
+    public static bool TripCreateStartsAt(this Line.TripCreate tripCreate, Stop stop) =>
+        Original.Line.Routes[tripCreate.RouteIndex].StopPositions[0].Stop == stop;
+
+    public static bool TripCreateEndsAt(this Line.TripCreate tripCreate, Stop stop) =>
+        Original.Line.Routes[tripCreate.RouteIndex].StopPositions[^1].Stop == stop;
 }

--- a/Timetables/Vip/Lines/Tram92/Tram92From20240923.cs
+++ b/Timetables/Vip/Lines/Tram92/Tram92From20240923.cs
@@ -1,0 +1,6 @@
+namespace Timetables.Vip.Lines.Tram92;
+
+public class Tram92From20240923
+{
+    
+}

--- a/Timetables/Vip/Lines/Tram92/Tram92From20241012Until20241013.cs
+++ b/Timetables/Vip/Lines/Tram92/Tram92From20241012Until20241013.cs
@@ -1,0 +1,10 @@
+using Timetables.Models;
+
+namespace Timetables.Vip.Lines.Tram92;
+
+public class Tram92From20241012Until20241013 : ILineInstance
+{
+    public DateOnly ValidFrom { get; } = new(2024, 10, 12);
+    public DateOnly? ValidUntilInclusive() => new(2024, 10, 13);
+    public Line Line { get; } = new Tram92From20240608().Line;
+}

--- a/Timetables/Vip/Lines/Tram92/Tram92From20241104.cs
+++ b/Timetables/Vip/Lines/Tram92/Tram92From20241104.cs
@@ -1,0 +1,14 @@
+using Timetables.Models;
+
+namespace Timetables.Vip.Lines.Tram92;
+
+public class Tram92From20241104 : ILineInstance
+{
+    private static readonly Tram92From20240422 Original = new();
+    public DateOnly ValidFrom { get; } = new(2024, 11, 4);
+
+    public Line Line { get; } = Original.Line with
+    {
+        Routes = Original.Line.Routes.Select(route => route.WithoutStop(Stops.ReiterwegAlleestr)).ToArray(),
+    };
+}

--- a/Timetables/Vip/Lines/Tram94/Tram94.cs
+++ b/Timetables/Vip/Lines/Tram94/Tram94.cs
@@ -8,5 +8,6 @@ internal class Tram94 : ICompleteLine
         new Tram94From20240211(),
         new Tram94From20240610(),
         new Tram94From20240826Until20240831(),
+        new Tram94From20241021Until20241102(),
     ];
 }

--- a/Timetables/Vip/Lines/Tram94/Tram94.cs
+++ b/Timetables/Vip/Lines/Tram94/Tram94.cs
@@ -9,5 +9,6 @@ internal class Tram94 : ICompleteLine
         new Tram94From20240610(),
         new Tram94From20240826Until20240831(),
         new Tram94From20241021Until20241102(),
+        new Tram94From20241104(),
     ];
 }

--- a/Timetables/Vip/Lines/Tram94/Tram94From20241021Until20241102.cs
+++ b/Timetables/Vip/Lines/Tram94/Tram94From20241021Until20241102.cs
@@ -1,0 +1,15 @@
+using Timetables.Models;
+
+namespace Timetables.Vip.Lines.Tram94;
+
+public class Tram94From20241021Until20241102 : ILineInstance
+{
+    private static readonly Tram94From20240610 Original = new();
+    public DateOnly ValidFrom { get; } = new(2024, 10, 21);
+    public DateOnly? ValidUntilInclusive() => new(2024, 11, 2);
+
+    public Line Line { get; } = Original.Line with
+    {
+        Routes = Original.Line.Routes.Select(route => route.WithoutStop(Stops.LuisenplatzSüdParkSanssouci)).ToArray(),
+    };
+}

--- a/Timetables/Vip/Lines/Tram94/Tram94From20241104.cs
+++ b/Timetables/Vip/Lines/Tram94/Tram94From20241104.cs
@@ -1,0 +1,11 @@
+using Timetables.Models;
+
+namespace Timetables.Vip.Lines.Tram94;
+
+public class Tram94From20241104 : ILineInstance
+{
+    private static readonly Tram94From20240211 Original = new();
+    public DateOnly ValidFrom { get; } = new(2024, 11, 4);
+
+    public Line Line { get; } = Original.Line;
+}

--- a/Timetables/Vip/Lines/Tram96/Tram96.cs
+++ b/Timetables/Vip/Lines/Tram96/Tram96.cs
@@ -6,6 +6,6 @@ internal class Tram96 : ICompleteLine
     [
         new Tram96From20240102(), new Tram96From20240606(), new Tram96From20240608(), new Tram96From20240610(),
         new Tram96From20240816Until20240818(), new Tram96From20240921Until20240922(),
-        new Tram96From20241012Until20241013(),
+        new Tram96From20241012Until20241013(), new Tram96From20241104(),
     ];
 }

--- a/Timetables/Vip/Lines/Tram96/Tram96.cs
+++ b/Timetables/Vip/Lines/Tram96/Tram96.cs
@@ -5,6 +5,7 @@ internal class Tram96 : ICompleteLine
     public IEnumerable<ILineInstance> LineInstances { get; } =
     [
         new Tram96From20240102(), new Tram96From20240606(), new Tram96From20240608(), new Tram96From20240610(),
-        new Tram96From20240816Until20240818(), new Tram96From20240921Until20240922()
+        new Tram96From20240816Until20240818(), new Tram96From20240921Until20240922(),
+        new Tram96From20241012Until20241013(),
     ];
 }

--- a/Timetables/Vip/Lines/Tram96/Tram96From20241012Until20241013.cs
+++ b/Timetables/Vip/Lines/Tram96/Tram96From20241012Until20241013.cs
@@ -1,0 +1,10 @@
+using Timetables.Models;
+
+namespace Timetables.Vip.Lines.Tram96;
+
+public class Tram96From20241012Until20241013 : ILineInstance
+{
+    public DateOnly ValidFrom { get; } = new(2024, 10, 12);
+    public DateOnly? ValidUntilInclusive() => new(2024, 10, 13);
+    public Line Line { get; } = new Tram96From20240608().Line;
+}

--- a/Timetables/Vip/Lines/Tram96/Tram96From20241104.cs
+++ b/Timetables/Vip/Lines/Tram96/Tram96From20241104.cs
@@ -1,0 +1,14 @@
+using Timetables.Models;
+
+namespace Timetables.Vip.Lines.Tram96;
+
+public class Tram96From20241104 : ILineInstance
+{
+    private static readonly Tram96From20240102 Original = new();
+    public DateOnly ValidFrom { get; } = new(2024, 11, 4);
+
+    public Line Line { get; } = Original.Line with
+    {
+        Routes = Original.Line.Routes.Select(route => route.WithoutStop(Stops.ReiterwegAlleestr)).ToArray(),
+    };
+}

--- a/Timetables/Vip/Lines/Tram98/Tram98.cs
+++ b/Timetables/Vip/Lines/Tram98/Tram98.cs
@@ -9,5 +9,6 @@ internal class Tram98 : ICompleteLine
         new Tram98From20240226(),
         new Tram98From20240809(),
         new Tram98From20240811(),
+        new Tram98From20241021Until20241102(),
     ];
 }

--- a/Timetables/Vip/Lines/Tram98/Tram98From20241021Until20241102.cs
+++ b/Timetables/Vip/Lines/Tram98/Tram98From20241021Until20241102.cs
@@ -1,0 +1,15 @@
+using Timetables.Models;
+
+namespace Timetables.Vip.Lines.Tram98;
+
+public class Tram98From20241021Until20241102 : ILineInstance
+{
+    private static readonly Tram98From20240811 Original = new();
+    public DateOnly ValidFrom { get; } = new(2024, 10, 21);
+    public DateOnly? ValidUntilInclusive() => new(2024, 11, 2);
+
+    public Line Line { get; } = Original.Line with
+    {
+        Routes = Original.Line.Routes.Select(route => route.WithoutStop(Stops.LuisenplatzSüdParkSanssouci)).ToArray(),
+    };
+}

--- a/Timetables/Vip/Lines/Tram99/Tram99.cs
+++ b/Timetables/Vip/Lines/Tram99/Tram99.cs
@@ -5,6 +5,6 @@ internal class Tram99 : ICompleteLine
     public IEnumerable<ILineInstance> LineInstances { get; } =
     [
         new Tram99From20240102(), new Tram99From20240608(), new Tram99From20240610(), new Tram99From20240816(),
-        new Tram99From20240826Until20240831()
+        new Tram99From20240826Until20240831(), new Tram99From20240921Until20240922(),
     ];
 }

--- a/Timetables/Vip/Lines/Tram99/Tram99.cs
+++ b/Timetables/Vip/Lines/Tram99/Tram99.cs
@@ -6,5 +6,6 @@ internal class Tram99 : ICompleteLine
     [
         new Tram99From20240102(), new Tram99From20240608(), new Tram99From20240610(), new Tram99From20240816(),
         new Tram99From20240826Until20240831(), new Tram99From20240921Until20240922(),
+        new Tram99From20241012Until20241013(),
     ];
 }

--- a/Timetables/Vip/Lines/Tram99/Tram99From20240921Until20240922.cs
+++ b/Timetables/Vip/Lines/Tram99/Tram99From20240921Until20240922.cs
@@ -1,6 +1,10 @@
+using Timetables.Models;
+
 namespace Timetables.Vip.Lines.Tram99;
 
-public class Tram99From20240921Until20240922
+public class Tram99From20240921Until20240922 : ILineInstance
 {
-    
+    public DateOnly ValidFrom { get; } = new(2024, 9, 21);
+    public DateOnly? ValidUntilInclusive() => new(2024, 9, 22);
+    public Line Line { get; } = new Tram99From20240608().Line;
 }

--- a/Timetables/Vip/Lines/Tram99/Tram99From20240921Until20240922.cs
+++ b/Timetables/Vip/Lines/Tram99/Tram99From20240921Until20240922.cs
@@ -1,0 +1,6 @@
+namespace Timetables.Vip.Lines.Tram99;
+
+public class Tram99From20240921Until20240922
+{
+    
+}

--- a/Timetables/Vip/Lines/Tram99/Tram99From20241012Until20241013.cs
+++ b/Timetables/Vip/Lines/Tram99/Tram99From20241012Until20241013.cs
@@ -1,0 +1,10 @@
+using Timetables.Models;
+
+namespace Timetables.Vip.Lines.Tram99;
+
+public class Tram99From20241012Until20241013 : ILineInstance
+{
+    public DateOnly ValidFrom { get; } = new(2024, 10, 12);
+    public DateOnly? ValidUntilInclusive() => new(2024, 10, 13);
+    public Line Line { get; } = new Tram99From20240608().Line;
+}

--- a/Timetables/Vip/VipHistory.cs
+++ b/Timetables/Vip/VipHistory.cs
@@ -105,6 +105,12 @@ public class VipHistory : IHistory
         new HistoryEntry(new DateOnly(2024, 10, 14), """
                                                      Die Sperrung ist wieder beendet.
                                                      """),
+        new HistoryEntry(new DateOnly(2024, 10, 21), """
+                                                     Aufgrund von Bauarbeiten wird während der Herbstferien die Haltestelle Luisenplatz-Süd/Park Sanssouci in beide Richtungen nicht bedient.
+                                                     """),
+        new HistoryEntry(new DateOnly(2024, 11, 3), """
+                                                     Die Haltestelle Luisenplatz-Süd/Park Sanssouci wird wieder bedient.
+                                                     """),
 
     ];
 }

--- a/Timetables/Vip/VipHistory.cs
+++ b/Timetables/Vip/VipHistory.cs
@@ -99,5 +99,12 @@ public class VipHistory : IHistory
                                                     Die Vollsperrung der Friedrich-Ebert-Straße ist wieder beendet, die Tramlinien 92 und 96 fahren wieder nach einem Baufahrplan.
                                                     Dieser wurde aber angepasst. So wird nun in beide Richtungen eine Minute weniger zwischen Puschkinallee und Rathaus eingeplant.
                                                     """),
+        new HistoryEntry(new DateOnly(2024, 10, 12), """
+                                                     Erneut ist die Friedrich-Ebert-Straße für ein Wochenende gesperrt.
+                                                     """),
+        new HistoryEntry(new DateOnly(2024, 10, 14), """
+                                                     Die Sperrung ist wieder beendet.
+                                                     """),
+
     ];
 }

--- a/Timetables/Vip/VipHistory.cs
+++ b/Timetables/Vip/VipHistory.cs
@@ -108,9 +108,21 @@ public class VipHistory : IHistory
         new HistoryEntry(new DateOnly(2024, 10, 21), """
                                                      Aufgrund von Bauarbeiten wird während der Herbstferien die Haltestelle Luisenplatz-Süd/Park Sanssouci in beide Richtungen nicht bedient.
                                                      """),
-        new HistoryEntry(new DateOnly(2024, 11, 3), """
-                                                     Die Haltestelle Luisenplatz-Süd/Park Sanssouci wird wieder bedient.
+        new HistoryEntry(new DateOnly(2024, 10, 26), """
+                                                     Die Friedrich-Ebert-Straße ist ein letztes Mal gesperrt, dieses Mal für über eine Woche.
+                                                     Abends in der Woche entfällt dabei die 92 zwischen Platz der Einheit und S Hauptbahnhof ersatzlos.
+                                                     Ebenso verkehrt der Ersatzverkehr der 92 in der Woche nur alle 20 Minuten.
+                                                     <br>
+                                                     <b>Die Fahrpläne fehlen aktuell noch.</b>
                                                      """),
+        new HistoryEntry(new DateOnly(2024, 11, 3), """
+                                                    Die Haltestelle Luisenplatz-Süd/Park Sanssouci wird wieder bedient.
+                                                    """),
+        new HistoryEntry(new DateOnly(2024, 11, 4), """
+                                                    Die Sperrung und Eingleisigkeit der Friedrich-Ebert-Straße sind beendet.
+                                                    Die Fahrpläne von vor der Sperrung treten wieder in Kraft.
+                                                    Die Haltestelle Reiterweg/Alleestr. wird weiterhin in beide Richtungen nicht bedient.
+                                                    """),
 
     ];
 }

--- a/Timetables/Vip/VipHistory.cs
+++ b/Timetables/Vip/VipHistory.cs
@@ -91,10 +91,13 @@ public class VipHistory : IHistory
                                                     Die Bauarbeiten in der Berliner Straße sind beendet, die Tram 93 fährt wieder nach dem regulären Fahrplan.
                                                     <br>
                                                     Außerdem ist an diesem Wochenende die Friedrich-Ebert-Straße wieder voll gesperrt.
-                                                    Es wird ein der Juni-Sperrung vergleichbares Konzept gefahren, allerdings ohne die Änderungen an der Tram 99.
+                                                    Es wird das Konzept der Juni-Sperrung vergleichbares gefahren, auch wenn die Änderungen an der Tram 99 diesmal nicht kommuniziert wurden.
                                                     Außerdem wird die Ersatzlinie der 92 am Sonntag mit einer Schleife von Campus Fachhochschule zusätzlich die Haltestelle Volkspark
                                                     bedienen, da dort an diesem Wochenende das Stadtwerke-Fest stattfindet.
                                                     """),
-        new HistoryEntry(new DateOnly(2024, 9, 23), "Die Vollsperrung der Friedrich-Ebert-Straße ist wieder beendet, die Tramlinien 92 und 96 fahren wieder nach dem regulären Baufahrplan."),
+        new HistoryEntry(new DateOnly(2024, 9, 23), """
+                                                    Die Vollsperrung der Friedrich-Ebert-Straße ist wieder beendet, die Tramlinien 92 und 96 fahren wieder nach einem Baufahrplan.
+                                                    Dieser wurde aber angepasst. So wird nun in beide Richtungen eine Minute weniger zwischen Puschkinallee und Rathaus eingeplant.
+                                                    """),
     ];
 }


### PR DESCRIPTION
Some recently published data by [ViP Potsdam](https://www.swp-potsdam.de/de/verkehr/) was incorrect, or rather incomplete. This PR attempts to fix these issues. However, it is quite hard to get all those changes as they are announced nowhere and thus have to be discovered in reality, instead.